### PR TITLE
Improve Timestamp Handling for Different Timezones

### DIFF
--- a/memos/cmds/library.py
+++ b/memos/cmds/library.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import logging.config
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import List, Tuple, Dict, Any, Optional, Set
 from functools import lru_cache
@@ -53,7 +53,7 @@ class FileStatus(Enum):
 def format_timestamp(timestamp):
     if isinstance(timestamp, str):
         return timestamp
-    return datetime.fromtimestamp(timestamp).replace(tzinfo=None).isoformat()
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).replace(tzinfo=None).isoformat()
 
 
 def init_file_detector():

--- a/memos/record.py
+++ b/memos/record.py
@@ -12,6 +12,7 @@ import ctypes
 from mss import mss
 from pathlib import Path
 from memos.config import settings
+import datetime
 
 # Import platform-specific modules
 if platform.system() == "Windows":
@@ -116,6 +117,12 @@ def take_screenshot_macos(
     displays_info = json.loads(result)["SPDisplaysDataType"][0]["spdisplays_ndrvs"]
     screen_names = {}
 
+    # Convert local time to UTC for metadata
+    local_dt = datetime.datetime.strptime(timestamp, "%Y%m%d-%H%M%S")
+    utc_offset = -time.timezone  # Get UTC offset in seconds
+    utc_dt = local_dt - datetime.timedelta(seconds=utc_offset)
+    utc_timestamp = utc_dt.strftime("%Y%m%d-%H%M%S")
+
     for display_index, display_info in enumerate(displays_info):
         base_screen_name = display_info["_name"].replace(" ", "_").lower()
         if base_screen_name in screen_names:
@@ -153,7 +160,7 @@ def take_screenshot_macos(
             screen_sequences[screen_name] = screen_sequences.get(screen_name, 0) + 1
 
             metadata = {
-                "timestamp": timestamp,
+                "timestamp": utc_timestamp,  # Use UTC timestamp in metadata
                 "active_app": app_name,
                 "active_window": window_title,
                 "screen_name": screen_name,
@@ -162,7 +169,7 @@ def take_screenshot_macos(
 
             # Save as WebP with metadata included
             webp_filename = os.path.join(
-                base_dir, date, f"screenshot-{timestamp}-of-{screen_name}.webp"
+                base_dir, date, f"screenshot-{timestamp}-of-{screen_name}.webp"  # Keep local time in filename
             )
             img.save(webp_filename, format="WebP", quality=85)
             write_image_metadata(webp_filename, metadata)
@@ -184,6 +191,12 @@ def take_screenshot_windows(
     app_name,
     window_title,
 ):
+    # Convert local time to UTC for metadata
+    local_dt = datetime.datetime.strptime(timestamp, "%Y%m%d-%H%M%S")
+    utc_offset = -time.timezone  # Get UTC offset in seconds
+    utc_dt = local_dt - datetime.timedelta(seconds=utc_offset)
+    utc_timestamp = utc_dt.strftime("%Y%m%d-%H%M%S")
+
     with mss() as sct:
         for i, monitor in enumerate(
             sct.monitors[1:], 1
@@ -217,7 +230,7 @@ def take_screenshot_windows(
             )
 
             metadata = {
-                "timestamp": timestamp,
+                "timestamp": utc_timestamp,  # Use UTC timestamp in metadata
                 "active_app": app_name,
                 "active_window": window_title,
                 "screen_name": safe_monitor_name,


### PR DESCRIPTION
## Changes

1. In `memos/cmds/library.py`:
   - Added `timezone` import from datetime module
   - Enhanced `format_timestamp` function to properly handle timezone conversion
   - Standardized timestamp conversion using Python's built-in timezone support

2. In `memos/record.py`:
   - Added timezone-aware timestamp handling
   - Modified screenshot metadata to store timezone-normalized timestamps
   - Maintained local timezone in filenames for better user experience

## Technical Details

- Standardized timestamp handling to ensure consistency across different timezones:
  ```python
  # Convert local time to UTC for consistent storage
  local_dt = datetime.datetime.strptime(timestamp, "%Y%m%d-%H%M%S")
  utc_offset = -time.timezone
  utc_dt = local_dt - datetime.timedelta(seconds=utc_offset)
  utc_timestamp = utc_dt.strftime("%Y%m%d-%H%M%S")
  ```

## Why

This change improves timestamp handling by:
1. Ensuring consistent timestamp behavior across different timezones
2. Maintaining user-friendly local time in filenames while storing normalized timestamps in metadata
3. Making the codebase more robust for users in different timezones