### PR TITLE
Bind to 127.0.0.1 by default, instead of 0.0.0.0

### DIFF
--- a/memos/default_config.yaml
+++ b/memos/default_config.yaml
@@ -16,7 +16,7 @@ default_library: screenshots
 screenshots_dir: screenshots
 # Directory for storing screenshots.
 
-server_host: 0.0.0.0
+server_host: 127.0.0.1
 # The host address to listen on.
 server_port: 8839
 # The port number to listen on.


### PR DESCRIPTION
使用 0.0.0.0 作为默认监听且无用户名/密码太过危险，这会导致局域网内的其他电脑可以访问所有截图。如果有公网IP，那么全网都能扫描并访问，非常危险

通过编辑默认配置文件的方式修改为 127.0.0.1（只让本地访问）

另外建议更新readme，提醒用户修改配置更新版本