### PR TITLE
修改使用模型的名字来修复从modelscope下载模型后仍提示huggingface.co无法连接的问题

### DIFF
--- a/memos/default_config.yaml
+++ b/memos/default_config.yaml
@@ -57,7 +57,7 @@ ocr:
 
 # using local embedding for English as the main language
 embedding:
-  model: arkohut/jina-embeddings-v2-base-en
+  model: jinaai/jina-embeddings-v2-base-en
   num_dim: 768
   use_local: true
   use_modelscope: false
@@ -89,7 +89,7 @@ watch:
 
 # using local embedding for Chinese as the main language
 # embedding:
-#   model: arkohut/jina-embeddings-v2-base-zh
+#   model: jinaai/jina-embeddings-v2-base-zh
 #   num_dim: 768
 #   use_local: true
 #   use_modelscope: true


### PR DESCRIPTION
默认配置文件修改为中文嵌入模型后，运行出问题，log里英文提示无法从huggingface.co下载，即使打开了modelscope的选项

检查配置文件后发现默认配置里的模型名是
`arkohut/jina-embeddings-v2-base-zh`
修改为readme里的
`jingai/jina-embeddings-v2-base-zh`

后恢复正常。