### PR TITLE
feat(ocr): make Apple Vision language_preference configurable

### DIFF
--- a/memos/config.py
+++ b/memos/config.py
@@ -35,6 +35,11 @@ class OCRSettings(BaseModel):
     concurrency: int = 8
     use_local: bool = True
     force_jpeg: bool = False
+    # Apple Vision language preference (macOS only, used when use_local=True).
+    # First language has the highest decoding weight. Default mixes Chinese and
+    # English so isolated Latin letters are not misread as digits in Chinese
+    # contexts (O→0, I→1, S→5, etc).
+    languages: List[str] = ["zh-Hans", "en-US"]
     # whether to enable the OCR plugin
     enabled: bool = True
 

--- a/memos/plugins/ocr/main.py
+++ b/memos/plugins/ocr/main.py
@@ -29,6 +29,7 @@ semaphore = None
 use_local = False
 ocr = None
 thread_pool = None
+languages = ["zh-Hans", "en-US"]
 
 # Configure logger
 logging.basicConfig(level=logging.INFO)
@@ -116,7 +117,7 @@ def predict_local(img_path):
         
         if platform.system() == 'Darwin' and not force_rapidocr:
             from ocrmac import ocrmac
-            ocr_result = ocrmac.OCR(img_path, language_preference=['zh-Hans']).recognize(px=True)
+            ocr_result = ocrmac.OCR(img_path, language_preference=languages).recognize(px=True)
             return convert_ocr_data(ocr_result)
         else:
             with Image.open(img_path) as img:
@@ -271,11 +272,12 @@ async def ocr(entity: Entity, request: Request):
 
 
 def init_plugin(config):
-    global endpoint, token, concurrency, semaphore, use_local, ocr, thread_pool
+    global endpoint, token, concurrency, semaphore, use_local, ocr, thread_pool, languages
     endpoint = config.endpoint
     token = config.token
     concurrency = config.concurrency
     use_local = config.use_local
+    languages = list(getattr(config, "languages", None) or ["zh-Hans", "en-US"])
     semaphore = asyncio.Semaphore(concurrency)
     
     if use_local:
@@ -297,3 +299,5 @@ def init_plugin(config):
     logger.info(f"Use local: {use_local}")
     if use_local:
         logger.info(f"OCR library: {'rapidocr_openvino' if platform.system() == 'Windows' and 'Intel' in cpuinfo.get_cpu_info()['brand_raw'] else 'rapidocr_onnxruntime'}")
+        if platform.system() == 'Darwin':
+            logger.info(f"Apple Vision languages: {languages}")


### PR DESCRIPTION
## Problem

On macOS, Pensieve uses Apple Vision for OCR with hardcoded `language_preference=['zh-Hans']` (`memos/plugins/ocr/main.py:119`).

When screenshots contain mixed Chinese + Latin content, the Chinese-only language hint biases the recognizer toward decoding isolated Latin letters as visually similar digits:

- `O` → `0`
- `I` / `l` → `1`
- `S` → `5`
- `B` → `8`
- `Z` → `2`

This silently corrupts OCR for code, URLs, license keys, command output, and any ASCII-heavy content captured on screen — exactly the kind of content many users want to search later.

## Fix

Add `ocr.languages: List[str]` setting, default `["zh-Hans", "en-US"]`, plumbed into `predict_local`. Users can:

- Keep the new default (mixed CN+EN) — solves the issue above.
- Reorder to `["en-US", "zh-Hans"]` for English-primary content.
- Set any list of BCP-47 codes Apple Vision supports.

Non-Darwin platforms ignore this setting (RapidOCR fallback unchanged).

## Behavior change

Default is now `['zh-Hans', 'en-US']` instead of `['zh-Hans']`. This is a behavior change for existing macOS users, but it strictly improves accuracy for any user whose screenshots contain Latin letters or digits, and I have not observed regression on pure-Chinese content. Happy to revert the default to `['zh-Hans']` if maintainers prefer — the value of the PR is making it configurable.

## Test plan
- [x] `OCRSettings()` loads with new default
- [x] `OCRSettings(languages=['en-US'])` overrides
- [x] Existing config files without `languages` field still work (default applies)
- [x] Local memos restart picks up the new setting and logs it