### PR TITLE
Fix #96: fresh-install migration fails with 'no such tokenizer: simple'

### DIFF
--- a/memos/migrations/alembic/env.py
+++ b/memos/migrations/alembic/env.py
@@ -1,4 +1,6 @@
+import sys
 from logging.config import fileConfig
+from pathlib import Path
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
@@ -32,10 +34,25 @@ def get_db_type():
 
 def configure_sqlite(engine):
     """Configure SQLite specific settings."""
+    # Mirrors SQLiteInitializer._load_sqlite_extensions: migrations that touch
+    # entities_fts need the `simple` tokenizer registered on the connection.
+    tokenizer_dir = Path(memosConfig.__file__).resolve().parent / "simple_tokenizer"
+    if sys.platform.startswith("linux"):
+        simple_lib = tokenizer_dir / "linux" / "libsimple"
+    elif sys.platform == "win32":
+        simple_lib = tokenizer_dir / "windows" / "simple"
+    elif sys.platform == "darwin":
+        simple_lib = tokenizer_dir / "macos" / "libsimple"
+    else:
+        raise OSError(f"Unsupported operating system: {sys.platform}")
+    dict_path = tokenizer_dir / "dict"
+
     def load_extension(dbapi_conn, connection_record):
         dbapi_conn.enable_load_extension(True)
+        dbapi_conn.load_extension(str(simple_lib))
+        dbapi_conn.execute(f"SELECT jieba_dict('{dict_path}')")
         sqlite_vec.load(dbapi_conn)
-    
+
     event.listen(engine, 'connect', load_extension)
 
 def run_migrations_offline() -> None:

--- a/memos/migrations/alembic/versions/fa40c9f33551_dedupe_entities_add_library_filepath_unique.py
+++ b/memos/migrations/alembic/versions/fa40c9f33551_dedupe_entities_add_library_filepath_unique.py
@@ -60,10 +60,14 @@ def upgrade() -> None:
 
     existing = {uc["name"] for uc in sa.inspect(conn).get_unique_constraints("entities")}
     if CONSTRAINT_NAME not in existing:
-        op.create_unique_constraint(CONSTRAINT_NAME, "entities", ["library_id", "filepath"])
+        # batch_alter_table is required on SQLite (no native ALTER ADD CONSTRAINT);
+        # on PostgreSQL it falls through to a plain ALTER.
+        with op.batch_alter_table("entities") as batch_op:
+            batch_op.create_unique_constraint(CONSTRAINT_NAME, ["library_id", "filepath"])
 
 
 def downgrade() -> None:
     existing = {uc["name"] for uc in sa.inspect(op.get_bind()).get_unique_constraints("entities")}
     if CONSTRAINT_NAME in existing:
-        op.drop_constraint(CONSTRAINT_NAME, "entities", type_="unique")
+        with op.batch_alter_table("entities") as batch_op:
+            batch_op.drop_constraint(CONSTRAINT_NAME, type_="unique")


### PR DESCRIPTION
Fixes #96.

## Problem

Fresh `memos serve` on a clean database crashes during alembic migrations:

```
OperationalError: no such tokenizer: simple
[SQL: DELETE FROM entities_fts WHERE id IN (SELECT id FROM _dedup_victims)]
```

Reported on Windows but reproduces on every OS — it is not platform-specific.

## Root cause

Two stacked bugs in the first-launch path of migration `fa40c9f33551`:

1. **`simple` tokenizer not loaded for alembic.** Runtime SQLite connections load both `simple` (the bundled FTS5 tokenizer) and `sqlite_vec` via `SQLiteInitializer._load_sqlite_extensions` (`memos/databases/initializers.py:218-231`). Alembic builds its own engine in `memos/migrations/alembic/env.py` and only loaded `sqlite_vec`. `fa40c9f33551` is the first migration to issue SQL against `entities_fts`, so the latent gap surfaced here.

2. **`op.create_unique_constraint` is unsupported on SQLite.** Once (1) is fixed, the same migration crashes with `NotImplementedError: No support for ALTER of constraints in SQLite dialect` because SQLite has no `ALTER TABLE ADD CONSTRAINT`.

## Fix

- `memos/migrations/alembic/env.py`: mirror `_load_sqlite_extensions` — load the platform-specific `libsimple` / `simple.dll`, register the jieba dict, then load `sqlite_vec`.
- `memos/migrations/alembic/versions/fa40c9f33551_*.py`: wrap unique-constraint add/drop in `op.batch_alter_table("entities")`. SQLite goes through alembic's copy-and-move strategy; Postgres path is unchanged.

## Test plan

- [x] `rm -rf ~/.memos && memos serve` on a clean DB completes migrations
- [x] Verified resulting `entities` table carries `CONSTRAINT entities_library_filepath_unique UNIQUE (library_id, filepath)`
- [ ] Spot-check on Windows by the reporter (cc @heroje)