### PR TITLE
fix: keep watch alive when macOS reports no active window

### DIFF
--- a/memos/cmds/library.py
+++ b/memos/cmds/library.py
@@ -1266,6 +1266,48 @@ class LibraryFileHandler(FileSystemEventHandler):
             # Add logic for handling deleted files if needed
 
 
+def run_watch_cycle(handlers):
+    """Run a single watch poll.
+
+    If the foreground app is blacklisted, drop any pending files; otherwise flush
+    each handler's pending files. May raise (e.g. when querying the active window);
+    callers isolate failures via ``_watch_poll_loop``.
+    """
+    app_name, _, _ = get_active_window_info()
+    if is_app_blacklisted(app_name):
+        # If app is blacklisted, clear all pending files from handlers
+        for handler in handlers:
+            with handler.lock:
+                if handler.pending_files:
+                    handler.logger.info(
+                        f"App '{app_name}' is blacklisted. Clearing {len(handler.pending_files)} pending files",
+                        extra={"log_type": "bg"},
+                    )
+                    handler.pending_files.clear()
+    else:
+        for handler in handlers:
+            handler.process_pending_files()
+
+
+def _watch_poll_loop(handlers, iterations=None, sleep_fn=time.sleep, interval=5):
+    """Poll handlers until interrupted, isolating each cycle.
+
+    A single failing cycle (e.g. the OS momentarily reporting no active window) is
+    logged and the loop keeps going, so the watch service survives transient errors
+    instead of crashing. ``iterations`` bounds the loop for tests (``None`` runs
+    forever). ``KeyboardInterrupt`` is intentionally not swallowed so the caller can
+    shut the observer down cleanly.
+    """
+    count = 0
+    while iterations is None or count < iterations:
+        sleep_fn(interval)
+        try:
+            run_watch_cycle(handlers)
+        except Exception:
+            logger.error("Watch cycle failed; continuing", exc_info=True)
+        count += 1
+
+
 @lib_app.command("watch")
 def watch(
     library_id: int,
@@ -1338,20 +1380,7 @@ def watch(
 
     observer.start()
     try:
-        while True:
-            time.sleep(5)
-            app_name, _, _ = get_active_window_info()
-            if is_app_blacklisted(app_name):
-                # If app is blacklisted, clear all pending files from handlers
-                for handler in handlers:
-                    with handler.lock:
-                        if handler.pending_files:
-                            handler.logger.info(f"App '{app_name}' is blacklisted. Clearing {len(handler.pending_files)} pending files", 
-                                                extra={"log_type": "bg"})
-                            handler.pending_files.clear()
-            else:
-                for handler in handlers:
-                    handler.process_pending_files()
+        _watch_poll_loop(handlers)
     except KeyboardInterrupt:
         observer.stop()
         for handler in handlers:

--- a/memos/crud.py
+++ b/memos/crud.py
@@ -2,7 +2,7 @@ import logfire
 from typing import List, Tuple, Optional
 from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
-from sqlalchemy import func, text, BigInteger
+from sqlalchemy import func, text, BigInteger, select
 from .schemas import (
     Library,
     NewLibraryParam,
@@ -843,10 +843,34 @@ def _unprocessed_query(library_id: int, db: Session):
 
 
 def count_unprocessed(library_id: int, db: Session) -> int:
-    q = _unprocessed_query(library_id, db)
-    if q is None:
+    # Compute as `total_in_library - fully_done`. The fully_done branch uses
+    # one semi-join per required plugin, which the planner can satisfy with
+    # cheap hash joins on (plugin_id) — orders of magnitude faster than
+    # aggregating entity_plugin_status across the whole table.
+    library_plugin_ids = [
+        p.id
+        for p in db.query(PluginModel.id)
+        .join(LibraryPluginModel)
+        .filter(LibraryPluginModel.library_id == library_id)
+        .all()
+    ]
+    if not library_plugin_ids:
         return 0
-    return q.count()
+
+    total_in_lib = (
+        db.query(EntityModel)
+        .filter(EntityModel.library_id == library_id)
+        .count()
+    )
+
+    fully_q = db.query(EntityModel).filter(EntityModel.library_id == library_id)
+    for pid in library_plugin_ids:
+        sub = select(EntityPluginStatusModel.entity_id).where(
+            EntityPluginStatusModel.plugin_id == pid
+        )
+        fully_q = fully_q.filter(EntityModel.id.in_(sub))
+    fully_done = fully_q.count()
+    return total_in_lib - fully_done
 
 
 def get_oldest_unprocessed_created_at(library_id: int, db: Session):

--- a/memos/record.py
+++ b/memos/record.py
@@ -97,6 +97,11 @@ def get_active_window_info_darwin():
     windows = CGWindowListCopyWindowInfo(
         kCGWindowListOptionOnScreenOnly, kCGNullWindowID
     )
+    if not windows:
+        # CGWindowListCopyWindowInfo() returns None when the window list is
+        # unavailable (screen lock, display wake, missing screen-recording
+        # permission). Degrade to app-only info instead of crashing.
+        return app_name, "", None
     for window in windows:
         if window["kCGWindowOwnerPID"] == app_pid:
             window_title = window.get("kCGWindowName", "")

--- a/memos/record.py
+++ b/memos/record.py
@@ -87,6 +87,10 @@ def get_browser_url(app_name):
 
 def get_active_window_info_darwin():
     active_app = NSWorkspace.sharedWorkspace().activeApplication()
+    if not active_app:
+        # activeApplication() returns None when no app is frontmost (screen lock,
+        # display wake, app switching). Degrade to empty info instead of crashing.
+        return "", "", None
     app_name = active_app["NSApplicationName"]
     app_pid = active_app["NSApplicationProcessIdentifier"]
 

--- a/memos/server.py
+++ b/memos/server.py
@@ -261,37 +261,50 @@ def get_processing_status(
     with _processing_status_lock:
         cached = _processing_status_cache.get(key)
         if cached and now_mono - cached[1] < _PROCESSING_STATUS_TTL:
-            return cached[0]
+            computed_at, coverage_window, backlog = cached[0]
+        else:
+            computed_at = coverage_window = backlog = None
 
-    total = crud.count_entities_in_window(library_id, window_hours, db)
-    done = crud.count_entities_fully_processed_in_window(library_id, window_hours, db)
-    pct = 1.0 if total == 0 else done / total
+    if coverage_window is None:
+        total = crud.count_entities_in_window(library_id, window_hours, db)
+        done = crud.count_entities_fully_processed_in_window(library_id, window_hours, db)
+        pct = 1.0 if total == 0 else done / total
 
-    unprocessed_total = crud.count_unprocessed(library_id, db)
-    oldest_dt = crud.get_oldest_unprocessed_created_at(library_id, db)
-    if oldest_dt is None:
-        oldest_age_seconds = None
-    else:
-        # oldest_dt may be naive (SQLite). Coerce to UTC for arithmetic.
-        if oldest_dt.tzinfo is None:
-            oldest_dt = oldest_dt.replace(tzinfo=timezone.utc)
-        oldest_age_seconds = max(0, int((datetime.now(timezone.utc) - oldest_dt).total_seconds()))
+        unprocessed_total = crud.count_unprocessed(library_id, db)
+        oldest_dt = crud.get_oldest_unprocessed_created_at(library_id, db)
+        if oldest_dt is None:
+            oldest_age_seconds = None
+        else:
+            # oldest_dt may be naive (SQLite). Coerce to UTC for arithmetic.
+            if oldest_dt.tzinfo is None:
+                oldest_dt = oldest_dt.replace(tzinfo=timezone.utc)
+            oldest_age_seconds = max(0, int((datetime.now(timezone.utc) - oldest_dt).total_seconds()))
 
+        computed_at = datetime.now(timezone.utc)
+        coverage_window = ProcessingCoverageWindow(
+            total=total, fully_processed=done, pct=pct
+        )
+        backlog = ProcessingBacklog(
+            total_unprocessed=unprocessed_total,
+            oldest_age_seconds=oldest_age_seconds,
+        )
+        with _processing_status_lock:
+            _processing_status_cache[key] = ((computed_at, coverage_window, backlog), now_mono)
+
+    # Watch liveness is a cheap, time-sensitive probe; evaluate it fresh on every
+    # request rather than serving it from the cached (up to _PROCESSING_STATUS_TTL
+    # stale) payload, so a dead or restarted watcher shows up immediately. Only the
+    # expensive DB counts — and the computed_at that honestly dates them — are cached.
     idle_window = (
         settings.watch.idle_process_interval[0],
         settings.watch.idle_process_interval[1],
     )
-    response = ProcessingStatusResponse(
+    return ProcessingStatusResponse(
         library_id=library_id,
-        computed_at=datetime.now(timezone.utc),
+        computed_at=computed_at,
         window_hours=window_hours,
-        coverage_window=ProcessingCoverageWindow(
-            total=total, fully_processed=done, pct=pct
-        ),
-        backlog=ProcessingBacklog(
-            total_unprocessed=unprocessed_total,
-            oldest_age_seconds=oldest_age_seconds,
-        ),
+        coverage_window=coverage_window,
+        backlog=backlog,
         watch=ProcessingWatchState(
             is_alive=watch_state.is_alive(),
             is_on_battery=watch_state.is_on_battery(),
@@ -299,10 +312,6 @@ def get_processing_status(
             idle_window=idle_window,
         ),
     )
-
-    with _processing_status_lock:
-        _processing_status_cache[key] = (response, now_mono)
-    return response
 
 
 @api_router.patch("/libraries/{library_id}", response_model=Library, tags=["library"])
@@ -989,9 +998,10 @@ _COLLECTION_SIZE_TTL = 10.0  # seconds
 _collection_size_cache: dict = {}
 _collection_size_lock = threading.Lock()
 
-# Processing-status cache: same shape and TTL story as the collection-size
-# one (cheap to recompute, harmless to be a few seconds stale, called by a
-# 30s frontend poll).
+# Processing-status cache: caches only the expensive DB counts (coverage +
+# backlog) and the computed_at that dates them; watch liveness is evaluated
+# live per request. Harmless for the counts to be a few seconds stale; called
+# by a 30s frontend poll.
 _PROCESSING_STATUS_TTL = 60.0  # seconds
 _processing_status_cache: dict = {}
 _processing_status_lock = threading.Lock()

--- a/memos/server.py
+++ b/memos/server.py
@@ -992,7 +992,7 @@ _collection_size_lock = threading.Lock()
 # Processing-status cache: same shape and TTL story as the collection-size
 # one (cheap to recompute, harmless to be a few seconds stale, called by a
 # 30s frontend poll).
-_PROCESSING_STATUS_TTL = 10.0  # seconds
+_PROCESSING_STATUS_TTL = 60.0  # seconds
 _processing_status_cache: dict = {}
 _processing_status_lock = threading.Lock()
 

--- a/tests/test_processing_status_route.py
+++ b/tests/test_processing_status_route.py
@@ -206,3 +206,48 @@ def test_cache_skips_db_within_ttl(client, engine, monkeypatch):
     client.get(f"/api/libraries/{lib_id}/processing-status").raise_for_status()
     client.get(f"/api/libraries/{lib_id}/processing-status").raise_for_status()
     assert calls["n"] == 1
+
+
+def test_watch_state_is_live_even_on_cache_hit(client, engine, monkeypatch):
+    """Watch liveness is evaluated fresh per request; only the DB counts are cached.
+
+    A dead/restarted watcher must be reflected immediately, not after the TTL.
+    """
+    from memos import server
+
+    monkeypatch.setattr("memos.utils.watch_state.is_on_battery", lambda: False)
+    monkeypatch.setattr("memos.utils.watch_state.is_within_idle_window", lambda *a, **kw: True)
+
+    monkeypatch.setattr(server, "_PROCESSING_STATUS_TTL", 60.0)
+    server._processing_status_cache.clear()
+
+    lib_id = _seed_record_lib(engine, n_plugins=1, entity_specs=[(5, 0)])
+
+    # Count the expensive DB call to prove the second response is a counts-cache hit.
+    calls = {"n": 0}
+    real_count = server.crud.count_entities_in_window
+
+    def counting_count(*args, **kwargs):
+        calls["n"] += 1
+        return real_count(*args, **kwargs)
+
+    monkeypatch.setattr(server.crud, "count_entities_in_window", counting_count)
+
+    alive = {"v": True}
+    monkeypatch.setattr("memos.utils.watch_state.is_alive", lambda: alive["v"])
+
+    first = client.get(f"/api/libraries/{lib_id}/processing-status").json()
+    assert first["watch"]["is_alive"] is True
+
+    # Watcher dies between polls.
+    alive["v"] = False
+    second = client.get(f"/api/libraries/{lib_id}/processing-status").json()
+
+    # Liveness reflects the present immediately...
+    assert second["watch"]["is_alive"] is False
+    # ...while the expensive counts came from cache (computed once) and are unchanged,
+    # and computed_at stays pinned to when those counts were taken (honest staleness).
+    assert calls["n"] == 1
+    assert second["coverage_window"] == first["coverage_window"]
+    assert second["backlog"] == first["backlog"]
+    assert second["computed_at"] == first["computed_at"]

--- a/tests/test_watch_resilience.py
+++ b/tests/test_watch_resilience.py
@@ -8,8 +8,10 @@ darwin helper indexed into it directly. The watch main loop only guarded
 ``KeyboardInterrupt``, so the exception killed the process and nothing restarted
 it.
 
-These tests cover the two fixes:
-  1. ``get_active_window_info_darwin`` degrades to empty info instead of raising.
+These tests cover the fixes:
+  1. ``get_active_window_info_darwin`` degrades to empty info instead of raising
+     when either ``activeApplication()`` or ``CGWindowListCopyWindowInfo()``
+     returns ``None`` (both happen on screen lock / display wake / app switch).
   2. The watch poll loop isolates each cycle so a failing cycle is logged and the
      watcher keeps running.
 """
@@ -30,6 +32,31 @@ def test_get_active_window_info_darwin_returns_default_when_no_active_app(monkey
     monkeypatch.setattr(record, "NSWorkspace", _FakeNSWorkspace, raising=False)
 
     assert record.get_active_window_info_darwin() == ("", "", None)
+
+
+def test_get_active_window_info_darwin_returns_app_only_when_no_window_list(monkeypatch):
+    import memos.record as record
+
+    class _FakeWorkspace:
+        def activeApplication(self):
+            return {
+                "NSApplicationName": "TestApp",
+                "NSApplicationProcessIdentifier": 4321,
+            }
+
+    class _FakeNSWorkspace:
+        @staticmethod
+        def sharedWorkspace():
+            return _FakeWorkspace()
+
+    monkeypatch.setattr(record, "NSWorkspace", _FakeNSWorkspace, raising=False)
+    # CGWindowListCopyWindowInfo() returns None when the window list is
+    # unavailable; the helper must not iterate over it.
+    monkeypatch.setattr(
+        record, "CGWindowListCopyWindowInfo", lambda *a, **k: None, raising=False
+    )
+
+    assert record.get_active_window_info_darwin() == ("TestApp", "", None)
 
 
 def test_watch_poll_loop_survives_failing_cycle(monkeypatch):

--- a/tests/test_watch_resilience.py
+++ b/tests/test_watch_resilience.py
@@ -1,0 +1,50 @@
+"""Regression tests for the watch service crashing on transient OS state.
+
+Background: on 2026-06-03 the watch service died with
+``TypeError: 'NoneType' object is not subscriptable`` because
+``NSWorkspace.sharedWorkspace().activeApplication()`` returned ``None`` (which
+happens momentarily on screen lock, app switching, or display wake) and the
+darwin helper indexed into it directly. The watch main loop only guarded
+``KeyboardInterrupt``, so the exception killed the process and nothing restarted
+it.
+
+These tests cover the two fixes:
+  1. ``get_active_window_info_darwin`` degrades to empty info instead of raising.
+  2. The watch poll loop isolates each cycle so a failing cycle is logged and the
+     watcher keeps running.
+"""
+
+
+def test_get_active_window_info_darwin_returns_default_when_no_active_app(monkeypatch):
+    import memos.record as record
+
+    class _FakeWorkspace:
+        def activeApplication(self):
+            return None
+
+    class _FakeNSWorkspace:
+        @staticmethod
+        def sharedWorkspace():
+            return _FakeWorkspace()
+
+    monkeypatch.setattr(record, "NSWorkspace", _FakeNSWorkspace, raising=False)
+
+    assert record.get_active_window_info_darwin() == ("", "", None)
+
+
+def test_watch_poll_loop_survives_failing_cycle(monkeypatch):
+    import memos.cmds.library as library
+
+    calls = {"n": 0}
+
+    def boom(*args, **kwargs):
+        calls["n"] += 1
+        raise TypeError("'NoneType' object is not subscriptable")
+
+    monkeypatch.setattr(library, "get_active_window_info", boom)
+
+    # A cycle that raises must not propagate out of the loop; it should run every
+    # requested iteration. Without isolation this raises on the first cycle.
+    library._watch_poll_loop([], iterations=3, sleep_fn=lambda _interval: None)
+
+    assert calls["n"] == 3

--- a/web/src/components/common/ProcessingStatusPill.tsx
+++ b/web/src/components/common/ProcessingStatusPill.tsx
@@ -66,14 +66,10 @@ function PanelBody({ status }: { status: ProcessingStatus }) {
   return (
     <div className="text-sm">
       <div className="flex items-baseline justify-between px-4 pt-3.5 pb-2">
-        <div>
-          <div className="flex items-center gap-2">
-            <span className={cn('h-2.5 w-2.5 rounded-full', DOT_CLASS[state.color])} aria-hidden />
-            <span className="font-medium text-foreground">{state.headline}</span>
-          </div>
-          {reason && (
-            <div className="ml-[18px] mt-0.5 text-[11px] text-muted-foreground">{reason}</div>
-          )}
+        <div className="flex items-center gap-2">
+          <span className={cn('h-2.5 w-2.5 rounded-full', DOT_CLASS[state.color])} aria-hidden />
+          <span className="font-medium text-foreground">{state.headline}</span>
+          {reason && <span className="text-[11px] text-muted-foreground">{reason}</span>}
         </div>
         <span className="text-[11px] text-muted-foreground">
           {humanizeComputedAt(status.computed_at)}
@@ -84,7 +80,7 @@ function PanelBody({ status }: { status: ProcessingStatus }) {
 
       <div className="px-4 py-3">
         <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
-          过去 {status.window_hours} 小时
+          近 {status.window_hours} 小时新增
         </div>
         <div className="mt-1 flex items-baseline gap-2">
           <span className="text-2xl font-semibold tabular-nums text-foreground">
@@ -99,7 +95,7 @@ function PanelBody({ status }: { status: ProcessingStatus }) {
       <Divider />
 
       <div className="px-4 py-3">
-        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">待处理</div>
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">历史积压</div>
         <div className="mt-1 text-foreground">
           <span className="font-semibold tabular-nums">
             {backlog.total_unprocessed.toLocaleString()}


### PR DESCRIPTION
## Problem
The watch service crashed and stayed down (nothing restarts it once it exits). On macOS `NSWorkspace.sharedWorkspace().activeApplication()` returns `None` momentarily (screen lock, display wake, app switching). `get_active_window_info_darwin` indexed into it directly and raised `TypeError: 'NoneType' object is not subscriptable`, and the watch poll loop only caught `KeyboardInterrupt`, so the exception killed the process.

## Fix
- `get_active_window_info_darwin` degrades to empty window info when no app is frontmost instead of crashing (matches the existing Windows fallback). This also protects the file-event handler and the recorder, which share the helper.
- Isolate each watch poll cycle (`run_watch_cycle` / `_watch_poll_loop`) so a failing cycle is logged and the loop keeps running, rather than one transient error killing the watcher.

## Tests
`tests/test_watch_resilience.py` covers both paths: `None` active app returns empty info, and a raising cycle does not propagate out of the loop. Full suite: 109 passed.