### PR TITLE
skill(pensieve-search): add entity-context strategy (grep -C for the timeline)

### DIFF
--- a/skills/pensieve-search/SKILL.md
+++ b/skills/pensieve-search/SKILL.md
@@ -67,7 +67,7 @@ Returns `SearchResult { hits: [...] }`. Each hit:
 }
 ```
 
-The `metadata_entries` is the goldmine — the VLM-extracted structured fields (`primary.app`, `primary.title_or_topic`, `primary.what`, `primary.workspace`) live inside the `structured_vlm_v1_*` entry's `value`. **The `value` is a parsed JSON object, not a string** — access fields directly with `.value.primary.what`. Do NOT pipe through `fromjson` (it will error with "only strings can be parsed"). The exact key suffix (e.g. `qwen3_6_35b`) varies per install — match with `select(.key | startswith("structured_vlm"))`.
+The `metadata_entries` is the goldmine — the VLM-extracted structured fields (`primary.app`, `primary.title_or_topic`, `primary.what`, `primary.workspace`) live inside the `structured_vlm_v1_*` entry's `value`. **In `/api/search` hits the `value` is a parsed JSON object, not a string** — access fields directly with `.value.primary.what`, and do NOT pipe through `fromjson` (it errors with "only strings can be parsed"). Note the inconsistency: `/api/entities/{id}` and the `/context` endpoint (Strategy 6) return the same `value` as a **JSON string**, where you *do* need `fromjson`. The portable branch is `(.value | if type=="string" then fromjson else . end)`. The exact key suffix (e.g. `qwen3_6_35b`) varies per install — match with `select(.key | startswith("structured_vlm"))`.
 
 **Important**: that JSON metadata is also fully tokenized into the FTS index. So `q="Claude Code Mastra workspace"` will match a screenshot whose VLM said `app=Claude Code, what="...Mastra...", workspace=...` — even if "Mastra" doesn't appear in the OCR text.
 
@@ -170,6 +170,74 @@ curl -s 'http://127.0.0.1:8839/api/search?q=mastra&facet=true&limit=5' \
 All three are populated only when `facet=true` (or when `settings.facet=true` server-side).
 
 To drill into a bucket, re-issue with `?date=YYYY-MM` or `?date=YYYY-MM-DD`. The server intersects `date` with the existing filters; if you also set `start`/`end`, the effective range is the overlap. After drilling into a month, the next response's `date_buckets` automatically adapts to days within that month.
+
+### Strategy 6 — context around an entity (`grep -C` for the timeline)
+
+Search *pinpoints* a moment; it doesn't show what surrounds it. When a hit lands on the right frame but the answer isn't *on* that frame — the working directory a command ran in, what led up to it, what happened next — pull its temporal neighbors. Think of it as `grep -C N` for the screenshot timeline: a natural, first-class move, especially the *before* side, where the lead-up lives (the cwd, the command typed, the app you came from).
+
+This is exactly what the web UI's context strip does, so mirror it.
+
+```
+GET /api/libraries/{library_id}/entities/{entity_id}/context?prev=N&next=N
+```
+
+- `prev` / `next` are **counts** (0–100 each), ordered by `file_created_at` — true temporal neighbors. This is robust where id arithmetic is **not**: entity ids are sparse and non-contiguous, so "fetch ids around X" silently misses frames. Always use this endpoint, never id math.
+- Returns `{ "prev": [entity…], "next": [entity…] }`. The target itself is **not** included — you supply it, like the frontend does. Each entity carries full `metadata_entries`.
+- **`library_id`** comes from the entity itself: `curl …/api/entities/{id} | jq .library_id` (or reuse `LIB` from the gap-audit section).
+- **Frontend parity** (`web/src/lib/api/entities.ts` → `fetchEntityContext`): the web UI calls `?prev=12&next=12` — a symmetric window of 12 (`grep -C 12`) — assembles `[...prev, target, ...next]` chronologically, and shows it raw (no dedup, no app-filtering). Match that default.
+
+**Two gotchas specific to this endpoint:**
+
+1. **It does NOT strip `ocr_result`** (unlike `/api/search`). A `prev=12&next=12` call is ~230 KB; `prev=100&next=100` is multi-MB. Always pipe to a tmp file and project only the fields you need.
+2. **Timestamps are naive UTC** — `2026-06-07T01:51:51`, no `Z`/offset (the rest of the API returns `+00:00`). To convert to local, normalize first: `.[0:19] + "Z" | fromdateiso8601 | strflocaltime(...)`. Skip this and you'll display the wrong hour.
+
+**Helper** (same spirit as `paged_search`): prints the chronological strip with the target marked, OCR stripped, times in local.
+
+```bash
+entity_context() {
+    local id="$1" size="${2:-12}"          # symmetric window, frontend default = 12
+    local tmp ctx lib
+    tmp=$(mktemp); ctx=$(mktemp)
+    curl -s "http://127.0.0.1:8839/api/entities/$id" > "$tmp"
+    lib=$(jq -r '.library_id' "$tmp")
+    curl -s "http://127.0.0.1:8839/api/libraries/$lib/entities/$id/context?prev=$size&next=$size" > "$ctx"
+    jq -r --slurpfile target "$tmp" '
+      def localt: .[0:19] + "Z" | fromdateiso8601 | strflocaltime("%H:%M:%S");
+      def row(tag): "\(.id)\t\(tag)\t\(.file_created_at|localt)\t"
+        + "\([.metadata_entries[]|select(.key=="active_app")|.value][0] // "?")\t"
+        + "\([.metadata_entries[]|select(.key=="active_window")|.value][0] // "-" | .[0:42])\t"
+        + ([.metadata_entries[]|select(.key|startswith("structured_vlm"))
+            | (.value | if type=="string" then fromjson else . end).primary.what][0] // "-" | .[0:40]);
+      (.prev[] | row("·")),
+      ($target[0] | row("▶ TARGET")),
+      (.next[] | row("·"))
+    ' "$ctx" | column -t -s $'\t'
+    rm -f "$tmp" "$ctx"
+}
+```
+
+Note the `(.value | if type=="string" then fromjson else . end)` branch: the `structured_vlm` value arrives as a **string** from `/api/entities` and `/context`, but as a **parsed object** from `/api/search` — this handles both. (`column -t` alignment drifts slightly with CJK widths; columns stay readable.)
+
+**Worked example — the directory a `codex` command ran in.** Search pinpointed the `codex` launch (entity `1748373`), but that frame was full-screen with the version-update prompt — no directory visible. Pull its context:
+
+```bash
+entity_context 1748373 8
+```
+
+```
+1748370  ·         09:51:40  iTerm2  ✳ Make claim status update on assessment a   在终端中运行 AI 编程助手，执行代码审查…
+1748372  ·         09:51:45  iTerm2  you@host:~/projects/memos/pensieve-rpa       在终端中执行 'z pensieve' 命令切换目录并准备运行…
+1748373  ▶ TARGET  09:51:51  iTerm2  codex                                        终端显示 Codex CLI 更新提示，等待用户输入…
+1748374  ·         09:51:56  iTerm2  ✳ Review blocking feature project for addi   …
+```
+
+The frame **6 s before** the launch (`1748372`) shows the shell prompt `…:~/projects/mem[os]` and a VLM note that the user ran `z pensieve` to jump directories — recovering the answer (`~/projects/memos/pensieve-rpa`) that wasn't on the target frame at all.
+
+**Adaptive widening** (mirrors clicking an edge thumbnail in the UI). If the lead-up frame isn't in the window yet:
+- bump the count: `entity_context <id> 30` → `60` → `100` (the per-side max), **or**
+- re-center on the oldest frame returned and pull *its* context — the same walk-further-back the UI does. Re-centering keeps each response small and lets you scan back indefinitely.
+
+**Citing it in a reply.** When context resolves the answer, cite the lead-up frame's entity URL next to the pinpoint hit, e.g. "ran in `~/projects/memos/pensieve-rpa` — the prompt is visible 6 s earlier → `http://127.0.0.1:8839/entities/1748372`". The user clicks through to verify the exact frame.
 
 ## Handling large result sets
 
@@ -507,6 +575,7 @@ Don't open more than 2-3 at a time — overwhelming. Pick the top hit, show its 
 7. **Old data without VLM**: screenshots predating structured_vlm rollout (or where VLM failed) only have OCR text. Their hits will lack the `structured_vlm_v1_*` entry — fall back to `ocr_result` for context.
 8. **`ocr_result` is not in search hits** — it's stripped from `/api/search` responses to keep them small (the full payload is ~15 KB per entry × 48 hits). The other metadata (timestamp, active_app, active_window, url, structured_vlm_*) is intact. If you genuinely need the OCR text for a specific entity, fetch `/api/entities/{id}` directly.
 9. **Chinese FTS noise is real**: the PG index uses jieba word segmentation, so a multi-character Chinese phrase gets split into smaller tokens. Common single-character morphemes (`网` / `站` / `中` etc.) match a lot of unrelated OCR (网络 / 网站 / 网址), so FTS will surface low-relevance hits mixed with the real ones. Hybrid RRF mitigates this somewhat via vector search, but for Chinese brand / site names always cross-check hits with URL or `active_app` filters (see Strategy 0) — don't trust the FTS rank alone.
+10. **The `/context` endpoint behaves unlike `/api/search`** (see Strategy 6): it does **not** strip `ocr_result` (responses balloon — pipe to a tmp file and project only what you need), its timestamps are **naive UTC** with no `Z`/offset (normalize with `.[0:19] + "Z"` before converting to local), and its `structured_vlm` value is a **JSON string** (needs `fromjson`, unlike search hits). Use the `entity_context` helper rather than hand-rolling these each time.
 
 ## When to give up and ask
 
@@ -517,5 +586,5 @@ Don't open more than 2-3 at a time — overwhelming. Pick the top hit, show its 
 ## What this skill does NOT do
 
 - ❌ Aggregate stats across days (use future "memos day" / cross-day analytics tools).
-- ❌ Find "everything I did on project X this week" — that needs the unfinished Activity / Session aggregation. For now, do a tight `q=X` + time window and let the user scrub.
+- ❌ Find "everything I did on project X this week" — that needs the unfinished Activity / Session aggregation. For now, do a tight `q=X` + time window and let the user scrub. (To reconstruct the *local* timeline around a single pinpointed moment, use Strategy 6 instead.)
 - ❌ Edit / delete entities. Read-only.


### PR DESCRIPTION
Adds one capability to the pensieve-search skill: pulling an entity's temporal context, framed as `grep -C N` for the screenshot timeline. Search pinpoints a moment but the answer often isn't on that frame (e.g. the cwd a command ran in lives a few frames earlier) — this teaches the skill to walk the neighbors instead of scrolling by hand.

## What's new (`Strategy 6`)
- Documents `GET /api/libraries/{lib}/entities/{id}/context?prev=N&next=N` — count-based temporal neighbors, robust against sparse/non-contiguous entity ids.
- Built to mirror the web frontend (`fetchEntityContext`): symmetric `size=12`, chronological `[prev, target, next]`, no dedup/filtering.
- Reusable `entity_context` helper (same style as `paged_search`): resolves `library_id`, strips the heavy OCR, converts naive-UTC → local, prints the strip with the target marked.
- Adaptive widening guidance (bump count, or re-center on the oldest frame — mirrors clicking an edge thumbnail in the UI).

## Endpoint quirks now called out
Unlike `/api/search`, the `/context` endpoint: does not strip `ocr_result`; returns naive-UTC timestamps (no `Z`/offset); and returns the `structured_vlm` value as a JSON string (needs `fromjson`). Cross-referenced in the metadata note, a new pitfall, and the "does NOT do" section.

Docs-only change to `skills/pensieve-search/SKILL.md`; no server/frontend code touched. Helper verified live against two entities.